### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://sysbrasil.visualstudio.com/c6711396-3155-43b9-b957-278ce37081f5/702fb6fa-22be-412f-bedb-efd2a22b3cfd/_apis/work/boardbadge/caf2fac5-afa4-4ccb-ab6e-8c551a017a33)](https://sysbrasil.visualstudio.com/c6711396-3155-43b9-b957-278ce37081f5/_boards/board/t/702fb6fa-22be-412f-bedb-efd2a22b3cfd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://sysbrasil.visualstudio.com/c6711396-3155-43b9-b957-278ce37081f5/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.